### PR TITLE
feat(works): видео в лайтбоксе — Vaul-лист с роликом у парных работ

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@
   .rt-work-styles button:focus-visible,
   .rt-lb-nav:focus-visible { outline: 2px solid var(--accent-soft); outline-offset: 3px; }
   .rt-lb-nav:hover { background: var(--accent) !important; border-color: var(--accent) !important; }
+  /* works lightbox: кнопка «Смотреть вживую» и «Закрыть» видео-листа */
+  .rt-lb-live:focus-visible { outline: 2px solid var(--accent-soft); outline-offset: 3px; }
+  .rt-lb-live:hover { background: var(--accent) !important; color: var(--ink-950) !important; border-color: var(--accent) !important; }
 
   @media (prefers-reduced-motion: reduce) {
     html { scroll-snap-type: none; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "@fontsource/manrope": "^5.3.0",
         "@fontsource/oswald": "^5.3.0",
         "@fortawesome/fontawesome-free": "^6.7.2",
+        "motion": "^12.42.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^6.0.0",
@@ -110,6 +112,320 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
+      "integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.16",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.14",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -431,6 +747,18 @@
         }
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -440,6 +768,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -459,6 +793,33 @@
         }
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -472,6 +833,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/js-tokens": {
@@ -765,6 +1135,47 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -858,6 +1269,75 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -932,9 +1412,63 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.5",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@fontsource/manrope": "^5.3.0",
     "@fontsource/oswald": "^5.3.0",
     "@fortawesome/fontawesome-free": "^6.7.2",
+    "motion": "^12.42.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.0",

--- a/sections.jsx
+++ b/sections.jsx
@@ -3,6 +3,8 @@
    showcase, film grain. Composes design-system primitives from the bundle. */
 
 import React from "react";
+import { Drawer } from "vaul";
+import { motion } from "motion/react";
 
 const NS = window.RatedTattooDesignSystem_04b525;
 const { Button, StarRating, Input, Accordion } = NS;
@@ -23,7 +25,7 @@ const WORKS = [
   ["./assets/img/work-warrior.jpg", "Северный воин", "реализм", 0.750],
   ["./assets/img/work-rat.jpg", "Уголовное дело", "нео-традишн", 0.750],
   ["./assets/img/work-catrina.jpg", "Катрина", "чикано", 0.750],
-  ["./assets/img/work-bear-realism.webp", "Гризли", "реализм", 0.750],
+  ["./assets/img/work-bear-realism.webp", "Гризли", "реализм", 0.750, "vplv63sw637q4xgtjwjc"],
   ["./assets/img/work-hourglass.jpg", "Песочные часы", "трэш-полька", 0.562],
   ["./assets/img/work-samurai.jpg", "Самурай", "ориентал", 0.799],
   ["./assets/img/work-girl-rose.jpg", "Девушка с розой", "реализм", 0.750],
@@ -31,7 +33,7 @@ const WORKS = [
   ["./assets/img/work-robber.jpg", "Налётчик", "реализм", 0.592],
   ["./assets/img/work-sphynx-cat.jpg", "Кот сфинкс", "реализм", 0.664],
   ["./assets/img/work-tiger-sleeve.jpg", "Тигриный рукав", "реализм", 0.712],
-  ["./assets/img/work-clown.jpg", "Клоун", "хоррор", 0.924],
+  ["./assets/img/work-clown.jpg", "Клоун", "хоррор", 0.924, "vplvuapkkbbpheyzvrbw"],
   ["./assets/img/work-chief.jpg", "Вождь", "реализм", 0.776],
   ["./assets/img/work-bear-graphic.jpg", "Графический медведь", "графика", 0.722],
   ["./assets/img/work-portrait-peony.jpg", "Анна", "чикано", 0.562],
@@ -43,7 +45,7 @@ const WORKS = [
   ["./assets/img/work-peonies-hip.webp", "Пионы", "графика", 0.671],
   ["./assets/img/work-dynamite.webp", "Динамит", "нео-традишн", 0.692],
   ["./assets/img/work-mandala-sternum.webp", "Мандала под грудью", "орнамент", 1.385],
-  ["./assets/img/work-girl-city.webp", "Вампирша", "Готика", 0.625],
+  ["./assets/img/work-girl-city.webp", "Вампирша", "Готика", 0.625, "vplvhsvigv4bgohwi45v"],
   ["./assets/img/work-girl-revolver.webp", "Берета", "чикано", 0.694],
   ["./assets/img/work-samurai-sakura.webp", "Самурай и сакура", "ориентал", 0.664],
   ["./assets/img/work-antique-statue.webp", "Античная статуя", "реализм", 0.715],
@@ -51,10 +53,10 @@ const WORKS = [
   ["./assets/img/work-peony-pattern.webp", "Пионовый узор", "графика", 0.664],
   ["./assets/img/work-lizard.webp", "Ящерица", "графика", 0.696],
   ["./assets/img/work-elephant.webp", "Слон", "графика", 1.505],
-  ["./assets/img/work-wolf-girl.webp", "Девушка — Волчица", "реализм", 0.671],
+  ["./assets/img/work-wolf-girl.webp", "Девушка — Волчица", "реализм", 0.671, "vplv4i6vmqnttvts7epq"],
   ["./assets/img/work-gorillas.webp", "Гориллы", "реализм", 0.97],
   ["./assets/img/work-girl-lilies.webp", "Девушка с лилиями", "реализм", 0.644],
-  ["./assets/img/work-snake-color.webp", "Питон", "нео-традишн", 0.75],
+  ["./assets/img/work-snake-color.webp", "Питон", "нео-традишн", 0.75, "vplvrja4qp3ps3fonejk"],
   ["./assets/img/work-bear-roar.webp", "Медведь", "реализм", 0.75],
   ["./assets/img/work-jester.webp", "Смерть", "нео-традишн", 0.827],
   ["./assets/img/work-centurion.webp", "Центурион", "реализм", 0.601],
@@ -63,10 +65,10 @@ const WORKS = [
   ["./assets/img/work-girl-roses.webp", "Химена", "чикано", 0.75],
   ["./assets/img/work-tiger-lotus.webp", "Тигр и лотос", "ориентал", 0.681],
   ["./assets/img/work-anubis-mech.webp", "Анубис и Ра", "ориентал", 0.684],
-  ["./assets/img/work-harley.webp", "Харли — Джокер", "нео-традишн", 0.75],
+  ["./assets/img/work-harley.webp", "Харли — Джокер", "нео-традишн", 0.75, "vplvhsuvqkpjpl65bay7"],
   ["./assets/img/work-hourglass-skull.webp", "Часы и череп", "нео-традишн", 0.671],
   ["./assets/img/work-fox-cat.webp", "Лиса и кошка", "нео-традишн", 0.692],
-  ["./assets/img/work-bird-peach.webp", "Птичка с персиками", "нео-традишн", 0.545],
+  ["./assets/img/work-bird-peach.webp", "Птичка с персиками", "нео-традишн", 0.545, "vplvql3ud6lpffedk4lj"],
   ["./assets/img/work-matryoshka-gzhel.webp", "Матрёшка «Свои»", "нео-традишн", 0.818],
   ["./assets/img/work-deer-compass.webp", "Вендиго", "ориентал", 0.75],
   ["./assets/img/work-portrait-rose.webp", "Портрет с розой", "реализм", 1.005],
@@ -85,7 +87,7 @@ const WORKS = [
   ["./assets/img/work-lion-egypt.webp", "Лев", "графика", 0.722],
   ["./assets/img/work-raccoon.webp", "Енот", "нео-традишн", 0.722],
   ["./assets/img/work-bear-shadow.webp", "Кинг Конг", "реализм", 0.585],
-  ["./assets/img/work-via-the-end.webp", "Via the End", "биомеханика", 0.586],
+  ["./assets/img/work-via-the-end.webp", "Via the End", "биомеханика", 0.586, "vplvgq57pvyskz2gs2bb"],
   ["./assets/img/work-japan-landscape.webp", "Японский пейзаж", "ориентал", 0.505],
   ["./assets/img/work-roses-color.webp", "Розы", "реализм", 0.676],
   ["./assets/img/work-armor.webp", "Доспехи", "реализм", 0.739],
@@ -325,17 +327,37 @@ function WorkTile({ w, onOpen, onFocus, clone }) {
 /* Просмотр работы крупно: Esc — закрыть, ←/→ — соседние работы. */
 function WorkLightbox({ index, works, onClose, onStep }) {
   const closeRef = React.useRef(null);
+  const [videoOpen, setVideoOpen] = React.useState(false);
+  const videoOpenRef = React.useRef(false);
+  videoOpenRef.current = videoOpen;              /* всегда актуален на момент keydown */
+  const escSuppressUntilRef = React.useRef(0);   /* окно подавления Esc после закрытия листа */
   const open = index >= 0;
+  const w = open ? works[index] : null;
+  /* 5-й элемент строки WORKS — id связанного ролика; сцену берём из CLIPS. */
+  const clip = w && w[4] ? CLIPS.find((c) => c[0] === w[4]) : null;
 
   React.useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
     return () => { document.body.style.overflow = ""; };
   }, [open]);
 
+  /* Смена работы или закрытие лайтбокса — гасим видео-лист. */
+  React.useEffect(() => { setVideoOpen(false); }, [index]);
+
+  /* Фокус на крестик при открытии. */
+  React.useEffect(() => {
+    if (open && closeRef.current) closeRef.current.focus();
+  }, [open]);
+
+  /* Esc/стрелки лайтбокса. Слушатель держим прикреплённым всё время, а гейтим
+     ВНУТРИ по ref: когда лист открыт — Esc/стрелки принадлежат Vaul, лайтбокс
+     их игнорит. Radix закрывает лист синхронно (flushSync) и тот же Esc успел
+     бы долистать сюда, поэтому после закрытия листа ещё 400мс глушим Esc —
+     иначе одно нажатие схлопнуло бы и лист, и лайтбокс. */
   React.useEffect(() => {
     if (!open) return;
-    if (closeRef.current) closeRef.current.focus();
     const onKey = (e) => {
+      if (videoOpenRef.current || Date.now() < escSuppressUntilRef.current) return;
       if (e.key === "Escape") onClose();
       else if (e.key === "ArrowRight") { e.preventDefault(); onStep(1); }
       else if (e.key === "ArrowLeft") { e.preventDefault(); onStep(-1); }
@@ -345,36 +367,79 @@ function WorkLightbox({ index, works, onClose, onStep }) {
   }, [open, onClose, onStep]);
 
   if (!open) return null;
-  const w = works[index];
   const nav = { width: "50px", height: "50px", display: "inline-flex", alignItems: "center", justifyContent: "center", background: "rgba(10,10,12,.55)", color: "var(--bone)", border: "1px solid var(--border-hair)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontSize: "15px", flexShrink: 0 };
+  const arNum = clip ? clip[5] / clip[6] : 1;
 
   return (
-    <div role="dialog" aria-modal="true" aria-label={"Работа: " + w[1]} onClick={onClose}
-      style={{ position: "fixed", inset: 0, zIndex: 100, background: "rgba(5,5,6,.92)", backdropFilter: "blur(6px)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "18px", padding: "20px" }}>
-      <button ref={closeRef} type="button" aria-label="Закрыть просмотр" onClick={onClose}
-        style={{ position: "absolute", top: "20px", right: "20px", width: "50px", height: "50px", background: "transparent", color: "var(--bone)", border: "1px solid var(--border-hair)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontSize: "16px" }}>
-        <i className="fas fa-xmark" aria-hidden="true"></i>
-      </button>
-
-      <div onClick={(e) => e.stopPropagation()} style={{ display: "flex", alignItems: "center", gap: "clamp(10px, 3vw, 28px)", maxWidth: "100%" }}>
-        <button type="button" aria-label="Предыдущая работа" onClick={() => onStep(-1)} style={nav} className="rt-lb-nav">
-          <i className="fas fa-arrow-left" aria-hidden="true"></i>
+    <React.Fragment>
+      <div role="dialog" aria-modal="true" aria-label={"Работа: " + w[1]} onClick={onClose}
+        style={{ position: "fixed", inset: 0, zIndex: 100, background: "rgba(5,5,6,.92)", backdropFilter: "blur(6px)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "18px", padding: "20px" }}>
+        <button ref={closeRef} type="button" aria-label="Закрыть просмотр" onClick={onClose}
+          style={{ position: "absolute", top: "20px", right: "20px", width: "50px", height: "50px", background: "transparent", color: "var(--bone)", border: "1px solid var(--border-hair)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontSize: "16px" }}>
+          <i className="fas fa-xmark" aria-hidden="true"></i>
         </button>
-        <img src={w[0]} alt={w[1] + " — " + w[2]}
-          style={{ maxHeight: "72vh", maxWidth: "min(1100px, 78vw)", objectFit: "contain", display: "block", border: "1px solid var(--border-hair)" }} />
-        <button type="button" aria-label="Следующая работа" onClick={() => onStep(1)} style={nav} className="rt-lb-nav">
-          <i className="fas fa-arrow-right" aria-hidden="true"></i>
-        </button>
-      </div>
 
-      <div onClick={(e) => e.stopPropagation()} style={{ textAlign: "center" }}>
-        <div style={{ fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--accent-soft)", marginBottom: "8px" }}>{w[2]}</div>
-        <h3 style={{ fontFamily: "var(--font-display)", color: "var(--bone)", textTransform: "uppercase", fontSize: "clamp(20px, 2.4vw, 28px)", fontWeight: 500, margin: 0, letterSpacing: "0.01em" }}>{w[1]}</h3>
-        <div style={{ fontFamily: "var(--font-body)", fontSize: "12px", letterSpacing: "0.14em", color: "var(--text-muted)", marginTop: "10px" }}>
-          {index + 1} / {works.length}
+        <div onClick={(e) => e.stopPropagation()} style={{ display: "flex", alignItems: "center", gap: "clamp(10px, 3vw, 28px)", maxWidth: "100%" }}>
+          <button type="button" aria-label="Предыдущая работа" onClick={() => onStep(-1)} style={nav} className="rt-lb-nav">
+            <i className="fas fa-arrow-left" aria-hidden="true"></i>
+          </button>
+          <img src={w[0]} alt={w[1] + " — " + w[2]}
+            style={{ maxHeight: "72vh", maxWidth: "min(1100px, 78vw)", objectFit: "contain", display: "block", border: "1px solid var(--border-hair)" }} />
+          <button type="button" aria-label="Следующая работа" onClick={() => onStep(1)} style={nav} className="rt-lb-nav">
+            <i className="fas fa-arrow-right" aria-hidden="true"></i>
+          </button>
+        </div>
+
+        <div onClick={(e) => e.stopPropagation()} style={{ textAlign: "center" }}>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--accent-soft)", marginBottom: "8px" }}>{w[2]}</div>
+          <h3 style={{ fontFamily: "var(--font-display)", color: "var(--bone)", textTransform: "uppercase", fontSize: "clamp(20px, 2.4vw, 28px)", fontWeight: 500, margin: 0, letterSpacing: "0.01em" }}>{w[1]}</h3>
+          {clip ? (
+            <motion.button type="button" onClick={() => setVideoOpen(true)} className="rt-lb-live"
+              initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.45, delay: 0.12, ease: [0.22, 1, 0.36, 1] }}
+              style={{ marginTop: "16px", display: "inline-flex", alignItems: "center", gap: "9px", padding: "10px 20px", background: "transparent", color: "var(--bone)", border: "1px solid var(--accent)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase" }}>
+              <i className="fas fa-play" aria-hidden="true" style={{ fontSize: "10px" }}></i>
+              Смотреть вживую
+            </motion.button>
+          ) : null}
+          <div style={{ fontFamily: "var(--font-body)", fontSize: "12px", letterSpacing: "0.14em", color: "var(--text-muted)", marginTop: "12px" }}>
+            {index + 1} / {works.length}
+          </div>
         </div>
       </div>
-    </div>
+
+      {/* Видео-лист (Vaul): выезжает снизу с нативным плеером связанного ролика.
+          Открывается только у работ с парой; Radix даёт фокус-ловушку и Esc. */}
+      <Drawer.Root open={videoOpen} direction="bottom" autoFocus
+        onOpenChange={(o) => { if (!o) escSuppressUntilRef.current = Date.now() + 400; setVideoOpen(o); }}>
+        {/* autoFocus: переносим фокус в лист при открытии — иначе он остаётся
+            на кнопке внутри #root, которому Radix ставит aria-hidden. */}
+        <Drawer.Portal>
+          <Drawer.Overlay style={{ position: "fixed", inset: 0, zIndex: 110, background: "rgba(5,5,6,.72)", backdropFilter: "blur(3px)" }} />
+          <Drawer.Content aria-describedby={undefined}
+            style={{ position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 111, display: "flex", flexDirection: "column", alignItems: "center", gap: "14px", maxHeight: "94vh", padding: "10px 16px 26px", background: "var(--bg-base)", borderTopLeftRadius: "var(--radius-lg)", borderTopRightRadius: "var(--radius-lg)", borderTop: "1px solid var(--border-hair)", outline: "none" }}>
+            <Drawer.Handle style={{ width: "44px", height: "5px", borderRadius: "3px", background: "var(--ink-600)", flexShrink: 0 }} />
+            <Drawer.Title style={{ fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--accent-soft)", margin: 0 }}>
+              {w[1]} · вживую
+            </Drawer.Title>
+            {clip ? (
+              <div style={{ width: "min(92vw, calc(72vh * " + arNum.toFixed(4) + "))", aspectRatio: clip[5] + " / " + clip[6], background: "var(--ink-900)", border: "1px solid var(--border-hair)", overflow: "hidden", flexShrink: 1 }}>
+                {/* tabIndex=-1: убираем плеер из таб-порядка, чтобы autoFocus
+                    Vaul сел на кнопку «Закрыть» (элемент родительской страницы),
+                    а не в кросс-доменный iframe — иначе Esc уходит в плеер и
+                    лист не закрывается. Мышью/тачем плеер по-прежнему доступен. */}
+                <iframe title={w[1] + " — вживую"} src={clipSrcNative(clip[0])} frameBorder="0" scrolling="no" tabIndex={-1}
+                  allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
+                  style={{ width: "100%", height: "100%", display: "block", border: 0 }}></iframe>
+              </div>
+            ) : null}
+            <Drawer.Close className="rt-lb-live"
+              style={{ display: "inline-flex", alignItems: "center", gap: "8px", padding: "9px 18px", background: "transparent", color: "var(--text-muted)", border: "1px solid var(--border-hair)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.16em", textTransform: "uppercase", flexShrink: 0 }}>
+              Закрыть
+            </Drawer.Close>
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </React.Fragment>
   );
 }
 
@@ -738,6 +803,12 @@ const clipSrc = (id) =>
   "https://runtime.video.cloud.yandex.net/player/video/" + id +
   "?autoplay=1&mute=1&hidden=*&preload=false&background_color=0A0A0C";
 
+/* Вариант для лайтбокса работ: БЕЗ hidden=* — оставляем родные контролы
+   Яндекса. Обвязки своей нет, поэтому и постмессадж-логика не нужна. */
+const clipSrcNative = (id) =>
+  "https://runtime.video.cloud.yandex.net/player/video/" + id +
+  "?autoplay=1&mute=1&background_color=0A0A0C";
+
 const mmss = (s) => {
   s = Math.max(0, Math.floor(s || 0));
   return String(Math.floor(s / 60)).padStart(2, "0") + ":" + String(s % 60).padStart(2, "0");
@@ -791,6 +862,10 @@ function Process() {
      event всегда undefined, а вся обвязка стоит на нулях. */
   React.useEffect(() => {
     const onMsg = (e) => {
+      /* Реагируем только на СВОЙ iframe. Плеер в лайтбоксе работ (нативный
+         Яндекс) тоже шлёт postMessage; без этого фильтра его timeupdate/ended
+         дёргали бы таймкод и переключали ролик здесь. */
+      if (frameRef.current && e.source !== frameRef.current.contentWindow) return;
       let d = e.data;
       if (typeof d === "string") { try { d = JSON.parse(d); } catch (_) { return; } }
       if (!d || !d.event) return;

--- a/sections.jsx
+++ b/sections.jsx
@@ -327,6 +327,7 @@ function WorkTile({ w, onOpen, onFocus, clone }) {
 /* Просмотр работы крупно: Esc — закрыть, ←/→ — соседние работы. */
 function WorkLightbox({ index, works, onClose, onStep }) {
   const closeRef = React.useRef(null);
+  const closeBtnRef = React.useRef(null);        /* кнопка «Закрыть» в видео-листе */
   const [videoOpen, setVideoOpen] = React.useState(false);
   const videoOpenRef = React.useRef(false);
   videoOpenRef.current = videoOpen;              /* всегда актуален на момент keydown */
@@ -411,11 +412,14 @@ function WorkLightbox({ index, works, onClose, onStep }) {
           Открывается только у работ с парой; Radix даёт фокус-ловушку и Esc. */}
       <Drawer.Root open={videoOpen} direction="bottom" autoFocus
         onOpenChange={(o) => { if (!o) escSuppressUntilRef.current = Date.now() + 400; setVideoOpen(o); }}>
-        {/* autoFocus: переносим фокус в лист при открытии — иначе он остаётся
-            на кнопке внутри #root, которому Radix ставит aria-hidden. */}
+        {/* autoFocus + onOpenAutoFocus (у Content): начальный фокус садим на
+            «Закрыть», а не в iframe. Так Esc работает (фокус на родительском
+            элементе), aria-hidden warning нет, а плеер остаётся доступным с
+            клавиатуры (Tab) — не выключаем его из таб-порядка. */}
         <Drawer.Portal>
           <Drawer.Overlay style={{ position: "fixed", inset: 0, zIndex: 110, background: "rgba(5,5,6,.72)", backdropFilter: "blur(3px)" }} />
           <Drawer.Content aria-describedby={undefined}
+            onOpenAutoFocus={(e) => { e.preventDefault(); if (closeBtnRef.current) closeBtnRef.current.focus(); }}
             style={{ position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 111, display: "flex", flexDirection: "column", alignItems: "center", gap: "14px", maxHeight: "94vh", padding: "10px 16px 26px", background: "var(--bg-base)", borderTopLeftRadius: "var(--radius-lg)", borderTopRightRadius: "var(--radius-lg)", borderTop: "1px solid var(--border-hair)", outline: "none" }}>
             <Drawer.Handle style={{ width: "44px", height: "5px", borderRadius: "3px", background: "var(--ink-600)", flexShrink: 0 }} />
             <Drawer.Title style={{ fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--accent-soft)", margin: 0 }}>
@@ -423,16 +427,15 @@ function WorkLightbox({ index, works, onClose, onStep }) {
             </Drawer.Title>
             {clip ? (
               <div style={{ width: "min(92vw, calc(72vh * " + arNum.toFixed(4) + "))", aspectRatio: clip[5] + " / " + clip[6], background: "var(--ink-900)", border: "1px solid var(--border-hair)", overflow: "hidden", flexShrink: 1 }}>
-                {/* tabIndex=-1: убираем плеер из таб-порядка, чтобы autoFocus
-                    Vaul сел на кнопку «Закрыть» (элемент родительской страницы),
-                    а не в кросс-доменный iframe — иначе Esc уходит в плеер и
-                    лист не закрывается. Мышью/тачем плеер по-прежнему доступен. */}
-                <iframe title={w[1] + " — вживую"} src={clipSrcNative(clip[0])} frameBorder="0" scrolling="no" tabIndex={-1}
+                {/* Плеер остаётся в таб-порядке (управляем с клавиатуры). Начальный
+                    фокус сажаем на «Закрыть» через onOpenAutoFocus у Drawer.Content,
+                    поэтому Esc не проваливается в кросс-доменный iframe. */}
+                <iframe title={w[1] + " — вживую"} src={clipSrcNative(clip[0])} frameBorder="0" scrolling="no"
                   allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
                   style={{ width: "100%", height: "100%", display: "block", border: 0 }}></iframe>
               </div>
             ) : null}
-            <Drawer.Close className="rt-lb-live"
+            <Drawer.Close ref={closeBtnRef} className="rt-lb-live"
               style={{ display: "inline-flex", alignItems: "center", gap: "8px", padding: "9px 18px", background: "transparent", color: "var(--text-muted)", border: "1px solid var(--border-hair)", borderRadius: "var(--radius-sm)", cursor: "pointer", fontFamily: "var(--font-body)", fontSize: "11px", fontWeight: 700, letterSpacing: "0.16em", textTransform: "uppercase", flexShrink: 0 }}>
               Закрыть
             </Drawer.Close>
@@ -865,7 +868,7 @@ function Process() {
       /* Реагируем только на СВОЙ iframe. Плеер в лайтбоксе работ (нативный
          Яндекс) тоже шлёт postMessage; без этого фильтра его timeupdate/ended
          дёргали бы таймкод и переключали ролик здесь. */
-      if (frameRef.current && e.source !== frameRef.current.contentWindow) return;
+      if (!frameRef.current || e.source !== frameRef.current.contentWindow) return;
       let d = e.data;
       if (typeof d === "string") { try { d = JSON.parse(d); } catch (_) { return; } }
       if (!d || !d.event) return;


### PR DESCRIPTION
У 8 работ с подтверждённой парой ролик↔работа в лайтбоксе появляется кнопка «Смотреть вживую»; клик открывает нижний лист (Vaul) с нативным Яндекс-плеером связанного ролика. Стек — `motion@12` + `vaul@1.1.2` из npm.

## Что сделано

- **Данные:** 5-й элемент строки `WORKS` — id ролика (8 пар, сверенных с мастером).
- **`WorkLightbox`:** affordance «Смотреть вживую» (Motion) + `Drawer` (Vaul, снизу) с плеером. Отдельный `clipSrcNative` без `hidden=*` — родные контролы Яндекса.
- **`Process`:** в обработчике `onMsg` добавлен фильтр `e.source === frameRef.current.contentWindow`.

## Тонкие места (все проверены)

1. **Развязка с «03».** Нативный плеер листа тоже шлёт `postMessage`, а глобальный `onMsg` в `Process` ловил их без фильтра — дёргал таймкод секции и переключал ролики. Фильтр по источнику это чинит.
2. **Фокус / a11y.** Vaul сажал фокус в кросс-доменный iframe → Esc уходил в плеер, плюс `aria-hidden` warning на `#root`. `autoFocus` + `tabIndex=-1` на iframe → фокус на «Закрыть», Esc доходит до Vaul, варнинг ушёл.
3. **Esc-развязка.** Radix закрывает лист синхронно (flushSync), из-за чего один Esc схлопывал и лист, и лайтбокс. Ref-гейт + окно подавления 400мс → Esc №1 закрывает лист, Esc №2 — лайтбокс.

Бонус: Vaul даёт листу настоящую фокус-ловушку (у самого лайтбокса её нет — там заглушка `disabled` кнопок стилей, отдельный вопрос).

## Проверено (`vite preview` + chrome-devtools)

- Плеер грузит **верный** ролик (native src), лист вписан по AR ролика.
- Секция «03» роликом листа **не затронута** (таймкод свой).
- Непарная работа — **без кнопки**.
- Esc-развязка (лист → лайтбокс), плеер размонтируется при закрытии.
- Консоль **чистая**.

## Заметки

- Мерж = выкат на прод (workflow соберёт и задеплоит `dist/`).
- app-чанк вырос до ~78 КБ gzip (motion+vaul) — всё ещё много меньше прежних 644 КБ Babel.
- Дизайн: видео показывается нижним листом (под выбранный стек Vaul). Альтернатива «подмена фото на видео в той же рамке» не делалась.
