### PR TITLE
Вход фонового видео Hero через занавес темноты (LCP не тронут)

### DIFF
--- a/sections.jsx
+++ b/sections.jsx
@@ -381,6 +381,7 @@ function Header({ onBook }) {
 /* ------------------------------------------------------------------- Hero */
 function Hero({ onBook }) {
   const entry = useHeroEntry();
+  const reduced = usePrefersReducedMotion();
   return (
     <section id="hero" className="rt-snap" style={{ position: "relative", minHeight: "100vh", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <div style={{ position: "absolute", inset: 0, zIndex: 0 }}>
@@ -390,6 +391,19 @@ function Hero({ onBook }) {
         </video>
         <div style={{ position: "absolute", inset: 0, background: "var(--scrim-hero)" }}></div>
       </div>
+
+      {/* «Проявление из темноты»: занавес поверх видео гаснет за ~0.9с. Само
+          видео при этом НЕ анимируется — оно рисуется сразу на полной
+          непрозрачности, поэтому LCP не сдвигается (в отличие от фейда самого
+          видео). Заодно движение видео на старте прикрыто чернотой и не
+          перебивает более тонкие reveal'ы секций. zIndex 0, но в DOM после
+          фонового слоя → красится над видео/скримом и под контентом (zIndex 1).
+          Под reduced-motion занавес не играем: initial:false рисует его сразу
+          прозрачным, без вспышки черноты. */}
+      <motion.div aria-hidden="true"
+        initial={reduced ? false : { opacity: 1 }} animate={{ opacity: 0 }}
+        transition={{ duration: reduced ? 0 : 0.9, ease: EASE_HEAVY }}
+        style={{ position: "absolute", inset: 0, zIndex: 0, background: "#0a0a0c", pointerEvents: "none" }} />
 
       {/* Боковая метка входит последней: она периферийная, и ведущей роли
           в первом кадре у неё нет. `transform` тут несёт раскладку (поворот),


### PR DESCRIPTION
Фоновое видео Hero — единственный крупный элемент первого экрана без входа: full-screen, движущееся, появлялось мгновенно и перебивало более тонкие reveal'ы секций. Правка даёт ему мягкий вход, не сдвигая LCP.

## Подход — занавес темноты, а не фейд видео

Наивный фейд самого видео (`opacity 0→1`) отложил бы **LCP** на длительность анимации: видео/постер крупнее заголовка и вероятный LCP-элемент. Вместо этого — отдельный тёмный оверлей поверх видео, гаснущий за 0.9с:

- видео рисуется сразу на полной непрозрачности → **LCP не тронут**;
- его движение на старте прикрыто чернотой → внимание не оттягивает;
- ложится в кинематографичный тон галереи.

Занавес — `zIndex: 0`, но в DOM после фонового слоя, поэтому красится над видео/скримом и под контентом (`zIndex: 1`). Под reduced-motion `initial: false` рисует его сразу прозрачным — без вспышки черноты.

## Замеры (`vite preview` + chrome-devtools)

| Проверка | Значение |
|---|---|
| Занавес | opacity **1 → 0** за ~0.8с от монтирования (t333 → чист t1106) |
| Видео | без инлайнового `opacity`/`transform` — **не анимируется** (LCP цел) |
| Reduced-motion | `peakOpacity: 0` — черноты нет вовсе |
| Консоль | пусто |

**Оговорка по LCP:** точное число через MCP-наблюдатель снять не удалось (буфер возвращал пусто — особенность инструмента этой сессии, не факт о сайте). Поэтому выбран подход, LCP-безопасный **по конструкции** — видео красится немедленно, анимируется только сторонний оверлей, — а не полагающийся на замер с запасом.

## Контекст

Всплыло при наблюдении владельца: постепенное появление блоков есть, но большое видео мгновенно перетягивало внимание. Reduced-motion и снятие входа у 4 секций (обе — заложенные решения) проверены и отметены; причина именно в видео Hero.

## За владельцем

- [ ] Preview-гейт: визуальная оценка «проявления из темноты» на `vite preview`.
- [ ] Реальные устройства: как читается занавес на медленной сети (видео грузится дольше — постер под занавесом).
- [ ] Squash-мерж (репо squash-only), затем прод-сверка по хэшу бандла.
